### PR TITLE
correct url encoding

### DIFF
--- a/google.go
+++ b/google.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"log"
+	"net/url"
 	"os/exec"
 	"runtime"
 	"strings"
@@ -21,16 +22,22 @@ func main() {
 	s := strings.Join(flag.Args(), "+") //Concatenates the args with '+'
 	println("let me google", s)
 
+	link, err := url.Parse("https://google.com/#q=" + s)
+	if err != nil {
+		println("Incorrect url")
+		return
+	}
+
 	cmd := new(exec.Cmd) //Pointer to newly allocated exec.Cmd type
 
 	switch runtime.GOOS {
 
 	case "linux":
-		cmd = exec.Command("xdg-open", "https://google.com/#q="+s)
+		cmd = exec.Command("xdg-open", link.String())
 	case "windows":
-		cmd = exec.Command("cmd", "/c", "start", "https://google.com/#q="+s)
+		cmd = exec.Command("cmd", "/c", "start", link.String())
 	case "darwin":
-		cmd = exec.Command("open", "https://google.com/#q="+s)
+		cmd = exec.Command("open", link.String())
 	default:
 		println("I don't know how to google it, on this OS.")
 		println("Open an issue at github.com/hariharan-uno/google")


### PR DESCRIPTION
For russian language command

```
google привет
```

google return 404 because russian in url have incorrect encoding. this PR fix this
